### PR TITLE
Handle Loatheb's Fungal Bloom

### DIFF
--- a/threat/spells.js
+++ b/threat/spells.js
@@ -53,6 +53,7 @@ const buffMultipliers = {
 	768:   getThreatCoefficient(0.71),		// Cat Form
 	25780: getThreatCoefficient({2:1.6}),	// Righteous Fury
 	26400: getThreatCoefficient(0.3),		// Fetish of the Sand Reaver
+	29232: getThreatCoefficient(0), 		// Fungal Bloom
 }
 
 // The leaf elements are functions (buffs,rank) => threatCoefficient
@@ -160,6 +161,7 @@ const fixateBuffs = {
 const notableBuffs = {
 	23397: true, // Nefarian's warrior class call
 	23398: true, // Druid class call
+	29232: true, // Fungal Bloom
 };
 for (let k in buffMultipliers) notableBuffs[k] = true;
 for (let k in invulnerabilityBuffs) notableBuffs[k] = true;

--- a/threat/threat.js
+++ b/threat/threat.js
@@ -585,6 +585,9 @@ class Fight {
 					delete u.buffs[9634];
 					u.buffs[768] = true;
 				}
+				if (i === 29232 && ev.type === "applydebuff") { // Fungal Bloom
+					u.buffs[29232] = true;
+				}
 				u.buffs[i] = true;
 				[_,enemies] = this.eventToFriendliesAndEnemies(ev, "target");
 				for (let k in enemies) {


### PR DESCRIPTION
Handle the Fungal Bloom debuff from Loatheb to set the threat coefficient to 0.

Changes the graph from:
![fungalbloombefore](https://user-images.githubusercontent.com/5982637/108783904-1e719f00-7523-11eb-82c1-83dd4e16628b.jpg)

To:
![fungalbloomafter](https://user-images.githubusercontent.com/5982637/108783929-28939d80-7523-11eb-8670-d333b2711622.jpg)


[Source logs](https://classic.warcraftlogs.com/reports/6qFBx1YHDm3CLv8a#fight=1&type=auras&view=events&ability=29232&source=26&spells=debuffs) 